### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/caojun0737/820bc28b-5531-47cc-b8b4-c2b7be2e03e0/462c1ee3-086f-45d5-b42a-7e1d4b96726d/_apis/work/boardbadge/eb415510-6892-412a-b211-c2b1c679fd4d)](https://dev.azure.com/caojun0737/820bc28b-5531-47cc-b8b4-c2b7be2e03e0/_boards/board/t/462c1ee3-086f-45d5-b42a-7e1d4b96726d/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/caojun0737/820bc28b-5531-47cc-b8b4-c2b7be2e03e0/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.